### PR TITLE
Change ranged value field structure

### DIFF
--- a/Packages/com.varneon.v-inspector/Editor/RangedValueFieldBuilder.cs
+++ b/Packages/com.varneon.v-inspector/Editor/RangedValueFieldBuilder.cs
@@ -10,17 +10,13 @@ namespace Varneon.VInspector
     {
         public static VisualElement Build(UnityEngine.Object target, SerializedProperty property, RangeAttribute rangeAttribute, string customName = null, string tooltip = null)
         {
-            VisualElement newField = new VisualElement();
-
-            newField.style.flexDirection = FlexDirection.Row;
-
             VisualElement slider;
 
             VisualElement valueField;
 
             string valueType = property.type;
 
-            if(valueType == "float")
+            if (valueType == "float")
             {
                 slider = new Slider(customName ?? property.displayName, rangeAttribute.min, rangeAttribute.max);
 
@@ -32,7 +28,7 @@ namespace Varneon.VInspector
                 valueField = new FloatField(string.Empty);
                 ((INotifyValueChanged<float>)valueField).RegisterValueChangedCallback(a => ((INotifyValueChanged<float>)valueField).SetValueWithoutNotify(Mathf.Clamp(a.newValue, rangeAttribute.min, rangeAttribute.max)));
             }
-            else if(valueType == "int")
+            else if (valueType == "int")
             {
                 slider = new SliderInt(customName ?? property.displayName, (int)rangeAttribute.min, (int)rangeAttribute.max);
 
@@ -52,15 +48,17 @@ namespace Varneon.VInspector
 
             slider.Q<Label>().RegisterPrefabPropertyOverrideContextClickEvent(target, property);
 
-            newField.Add(slider);
-
             valueField.style.width = new StyleLength(50f);
+
+            valueField.style.marginBottom = 0;
+            valueField.style.marginRight = 0;
+            valueField.style.marginTop = 0;
 
             ((BindableElement)valueField).BindProperty(property);
 
-            newField.Add(valueField);
+            slider.Add(valueField);
 
-            return newField;
+            return slider;
         }
     }
 }


### PR DESCRIPTION
RangedValueFieldBuilder now uses Slider as a base for the ranged field instead of a new VisualElement.

FloatField now gets appended to the Slider element instead of the field root VisualElement.

This preserves the relative element sizes of the Slider and allows for easier style sheet customization.

Restructuring of the ranged value field makes it significantly easier to alignment and width adjustment of the fields when using custom USS styles:

![image](https://user-images.githubusercontent.com/26690821/194807935-f510928a-d9c5-4935-9cee-70758c353edd.png)